### PR TITLE
Add Swashbuckle dependency

### DIFF
--- a/ChatGptApi/ChatGptApi.csproj
+++ b/ChatGptApi/ChatGptApi.csproj
@@ -4,4 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
 </Project>

--- a/ChatGptApi/Program.cs
+++ b/ChatGptApi/Program.cs
@@ -1,4 +1,5 @@
 using ChatGptApi;
+using Microsoft.OpenApi.Models;
 
 Console.Write("What is your name? ");
 var name = Console.ReadLine();


### PR DESCRIPTION
## Summary
- Reference `Swashbuckle.AspNetCore` package in the API project
- Include OpenAPI namespace for Swagger support

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689cac5032b08327a03f2913dbbfe041